### PR TITLE
Add example use to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,31 @@ This crate provides an extension trait for String with two methods, `into_chars`
   - Rewrite to use `delegate` crate
   - Fix/breaking change: `OwnedChars::as_str` works the same way as `std::Chars::as_str`
 
+### Example
+
+```rust
+use owned_chars::OwnedChars;
+
+fn main() {
+    let mut chars = OwnedChars::from_string("0123456789ABCDEF".to_owned());
+    let next_is_digit = |chars: &mut OwnedChars| chars.next().map_or(false, |c| c.is_numeric());
+
+    assert!(next_is_digit(&mut chars)); // 0
+    assert!(next_is_digit(&mut chars)); // 1
+    assert!(next_is_digit(&mut chars)); // 2
+    assert!(next_is_digit(&mut chars)); // 3
+    assert!(next_is_digit(&mut chars)); // 4
+    assert!(next_is_digit(&mut chars)); // 5
+    assert!(next_is_digit(&mut chars)); // 6
+    assert!(next_is_digit(&mut chars)); // 7
+    assert!(next_is_digit(&mut chars)); // 8
+    assert!(next_is_digit(&mut chars)); // 9
+
+    assert!(!next_is_digit(&mut chars)); // A
+    assert!(!next_is_digit(&mut chars)); // B
+    assert!(!next_is_digit(&mut chars)); // C
+    assert!(!next_is_digit(&mut chars)); // D
+    assert!(!next_is_digit(&mut chars)); // E
+    assert!(!next_is_digit(&mut chars)); // F
+}
+```


### PR DESCRIPTION
Thanks for this crate! It's been very helpful in a project I'm working on.

This PR contains a commit that adds simple example program showing the use of `OwnedChars::from_string`.

[Rendered](https://github.com/nickrtorres/owned-chars/blob/readme-example/README.md#example)