### PR TITLE
Polish the crate documentation and structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,20 @@ mod structs {
                 }
 
                 #[delegate(self.i)]
-                /// Borrow the contained String
+                /// Views the underlying data as a subslice of the original data.
+                /// 
+                /// # Example
+                ///
+                /// ```rust
+                /// # use owned_chars::{OwnedChars, OwnedCharsExt};
+                /// let mut chars: OwnedChars = String::from("abc").into_chars();
+                /// assert_eq!(chars.as_str(), "abc");
+                /// chars.next();
+                /// assert_eq!(chars.as_str(), "bc");
+                /// chars.next();
+                /// chars.next();
+                /// assert_eq!(chars.as_str(), "");
+                /// ```
                 pub fn as_str(&self) -> &str;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,14 @@
 #![deny(missing_docs)]
 
-//! This crate provides two owned iterators over String: OwnedChars and OwnedCharIndices. They have
-//! the same output as Chars and CharIndices, but creating the iterator consumes the String as
+//! This crate provides two owned iterators over String: [OwnedChars] and [OwnedCharIndices]. They have
+//! the same output as [Chars] and [CharIndices], respectively, but creating the iterator consumes the String as
 //! opposed to borrowing.
 //! 
 //! Do you think this should be included in Rust proper? [Comment
 //! here](https://github.com/durka/owned-chars/issues/5) if so!
+//! 
+//! [Chars]: std::str::Chars
+//! [CharIndices]: std::str::CharIndices
 
 #[macro_use]
 extern crate delegate_attr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,14 @@ mod structs {
     use std::mem::transmute;
     use std::str::{CharIndices, Chars};
 
-    /// Iterator over the chars of a string (the string is owned by the iterator).
+    /// An iterator over the [`char`]s of an owned `String`.
     #[derive(Debug)]
     pub struct OwnedChars {
         s: String,
         i: Chars<'static>,
     }
 
-    /// Iterator over the chars of a string and their indices (the string is owned by the iterator).
+    /// An iterator over the [`char`]s of an owned `String`, and their positions.
     #[derive(Debug)]
     pub struct OwnedCharIndices {
         s: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod structs {
                     }
                 }
 
-                /// Consume this struct and return the contained String.
+                /// Consumes the iterator, returning the contained `String`.
                 pub fn into_inner(self) -> String {
                     self.s
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,35 +127,39 @@ mod structs {
 
 pub use structs::*;
 
-#[test]
-fn chars() {
-    let s = String::from("héllo");
-    assert_eq!(s.chars().collect::<Vec<_>>(),
-               s.into_chars().collect::<Vec<_>>());
-}
+#[cfg(test)]
+mod tests {
+    use crate::OwnedCharsExt;
 
-#[test]
-fn unicode() {
-    let s = String::from("héllo");
-    assert_eq!(Some('é'), s.clone().into_chars().skip(1).next());
-    assert_eq!(Some('l'), s.clone().into_chars().skip(2).next());
-}
+    #[test]
+    fn chars() {
+        let s = String::from("héllo");
+        assert_eq!(s.chars().collect::<Vec<_>>(),
+                s.into_chars().collect::<Vec<_>>());
+    }
 
-#[test]
-fn char_indices() {
-    let s = String::from("héllo");
-    assert_eq!(s.char_indices().collect::<Vec<_>>(),
-               s.into_char_indices().collect::<Vec<_>>());
-}
+    #[test]
+    fn unicode() {
+        let s = String::from("héllo");
+        assert_eq!(Some('é'), s.clone().into_chars().skip(1).next());
+        assert_eq!(Some('l'), s.clone().into_chars().skip(2).next());
+    }
 
-#[test]
-fn methods() {
-    let s = String::from("héllo");
-    let oc = s.clone().into_chars();
-    let oci = s.clone().into_char_indices();
-    assert_eq!(&s, oc.as_str());
-    assert_eq!(&s, oci.as_str());
-    assert_eq!(s, oc.into_inner());
-    assert_eq!(s, oci.into_inner());
-}
+    #[test]
+    fn char_indices() {
+        let s = String::from("héllo");
+        assert_eq!(s.char_indices().collect::<Vec<_>>(),
+                s.into_char_indices().collect::<Vec<_>>());
+    }
 
+    #[test]
+    fn methods() {
+        let s = String::from("héllo");
+        let oc = s.clone().into_chars();
+        let oci = s.clone().into_char_indices();
+        assert_eq!(&s, oc.as_str());
+        assert_eq!(&s, oci.as_str());
+        assert_eq!(s, oc.into_inner());
+        assert_eq!(s, oci.into_inner());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,14 @@ extern crate delegate_attr;
 
 /// Extension trait for String providing owned char and char-index iterators
 pub trait OwnedCharsExt {
-    /// Gets an owning iterator over the chars (see `chars()`)
+    /// Returns an owning iterator over the [`char`]s of a string.
+    ///
+    /// It is an owning alternative to [`str::chars`] method.
     fn into_chars(self) -> OwnedChars;
-    /// Gets an owning iterator over the chars and their indices (see `char_indices()`)
+
+    /// Returns an owning iterator over the [`char`]s of a string, and their positions.
+    ///
+    /// It is an owning alternative to [`str::char_indices`] method.
     fn into_char_indices(self) -> OwnedCharIndices;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 //! This crate provides two owned iterators over String: [OwnedChars] and [OwnedCharIndices]. They have
 //! the same output as [Chars] and [CharIndices], respectively, but creating the iterator consumes the String as
 //! opposed to borrowing.
-//! 
+//!
 //! Do you think this should be included in Rust proper? [Comment
 //! here](https://github.com/durka/owned-chars/issues/5) if so!
-//! 
+//!
 //! [Chars]: std::str::Chars
 //! [CharIndices]: std::str::CharIndices
 
@@ -37,9 +37,9 @@ impl OwnedCharsExt for String {
 }
 
 mod structs {
-    use std::str::{Chars, CharIndices};
-    use std::iter::{Iterator, DoubleEndedIterator, FusedIterator};
+    use std::iter::{DoubleEndedIterator, FusedIterator, Iterator};
     use std::mem::transmute;
+    use std::str::{CharIndices, Chars};
 
     /// Iterator over the chars of a string (the string is owned by the iterator).
     #[derive(Debug)]
@@ -58,11 +58,7 @@ mod structs {
     macro_rules! impls {
         ($owned_struct:ident, $target_struct:ident, $method: ident, $item: ty) => {
             impl $owned_struct {
-                #[doc = concat!(
-                    "Creates new `",
-                    stringify!($owned_struct),
-                    "` from the String.",
-                )]
+                #[doc = concat!("Creates new `", stringify!($owned_struct), "` from the String.")]
                 pub fn from_string(s: String) -> Self {
                     unsafe {
                         // First, we can call .chars/.char_indices, whose result will have the same
@@ -86,7 +82,7 @@ mod structs {
 
                 #[delegate(self.i)]
                 /// Views the underlying data as a subslice of the original data.
-                /// 
+                ///
                 /// # Example
                 ///
                 /// ```rust
@@ -134,8 +130,10 @@ mod tests {
     #[test]
     fn chars() {
         let s = String::from("héllo");
-        assert_eq!(s.chars().collect::<Vec<_>>(),
-                s.into_chars().collect::<Vec<_>>());
+        assert_eq!(
+            s.chars().collect::<Vec<_>>(),
+            s.into_chars().collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -148,8 +146,10 @@ mod tests {
     #[test]
     fn char_indices() {
         let s = String::from("héllo");
-        assert_eq!(s.char_indices().collect::<Vec<_>>(),
-                s.into_char_indices().collect::<Vec<_>>());
+        assert_eq!(
+            s.char_indices().collect::<Vec<_>>(),
+            s.into_char_indices().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ impl OwnedCharsExt for String {
     }
 }
 
-/// structs
 mod structs {
     use std::str::{Chars, CharIndices};
     use std::iter::{Iterator, DoubleEndedIterator, FusedIterator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #[macro_use]
 extern crate delegate_attr;
 
-/// Extension trait for String providing owned char and char-index iterators
+/// Extension trait for String providing owned char and char-index iterators.
 pub trait OwnedCharsExt {
     /// Returns an owning iterator over the [`char`]s of a string.
     ///
@@ -42,14 +42,14 @@ mod structs {
     use std::iter::{Iterator, DoubleEndedIterator, FusedIterator};
     use std::mem::transmute;
 
-    /// Iterator over the chars of a string (the string is owned by the iterator)
+    /// Iterator over the chars of a string (the string is owned by the iterator).
     #[derive(Debug)]
     pub struct OwnedChars {
         s: String,
         i: Chars<'static>,
     }
 
-    /// Iterator over the chars of a string and their indices (the string is owned by the iterator)
+    /// Iterator over the chars of a string and their indices (the string is owned by the iterator).
     #[derive(Debug)]
     pub struct OwnedCharIndices {
         s: String,
@@ -80,7 +80,7 @@ mod structs {
                     }
                 }
 
-                /// Consume this struct and return the contained String
+                /// Consume this struct and return the contained String.
                 pub fn into_inner(self) -> String {
                     self.s
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,11 @@ mod structs {
     macro_rules! impls {
         ($owned_struct:ident, $target_struct:ident, $method: ident, $item: ty) => {
             impl $owned_struct {
-                /// Create Self from a String, moving the String into Self
+                #[doc = concat!(
+                    "Creates new `",
+                    stringify!($owned_struct),
+                    "` from the String.",
+                )]
                 pub fn from_string(s: String) -> Self {
                     unsafe {
                         // First, we can call .chars/.char_indices, whose result will have the same


### PR DESCRIPTION
I've made some polishing to the crate.

# Motivation

Incorrect documentation of an `as_str` method made me spend some time debugging, so I've decided to fix it. I couldn't stop after that.

# Changes

- Fixed documentation of `as_str`. It used to have obsolete documentation from the pre-3.0 version;
- Updated documentation to make it look more like `std`'s;
- Added item links to items where they looked proper;
- Moved tests in submodule guarded by `cfg(test)`. It saves compilation time and follows guidelines.

# Drawbacks

- Documentation of `from_string` uses macro to insert proper name. It is rendered great by rustdoc, but rust-analyzer is not able to show that documentation at the moment. I consider it acceptable as the main way to create the structs is `OwnedCharsExt` trait;
- Both `OwnedChars` and `OwnedCharIndices` have the same example for `as_str`. It may be easily fixed by macro, but aforementioned problem with rust-analyzer occurs. However, both structs are similar, so an identical example isn't much of a trouble.

# Further improvements

- Probably some mention of `into_chars` and `into_char_indices` in top-level documentation would be useful;
- I've decided not to do anything with `structs` module, but it looks pretty useless at the moment and may be removed;
- Specify 2021 edition. Due to the lack of `edition` entry in `Cargo.toml`, 2015 edition is used by Cargo;

Globally speaking, does `delegate-attr` even worth it? That crate would be dependency-free if it implemented few methods by itself, however, it now has some heavy dependencies (proc-macro2, syn, quote). Currently, it is just six one-line bodies to implement to replace `delegate-attr`.

I may create pull requests for any/all entries you find worthy, just let me know!