### PR TITLE
Add `get_inner` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,24 @@ mod structs {
                     self.s
                 }
 
+                /// Returns a string slice of contained `String`.
+                ///
+                /// # Example
+                ///
+                /// ```rust
+                /// # use owned_chars::{OwnedChars, OwnedCharsExt};
+                /// let mut chars: OwnedChars = String::from("abc").into_chars();
+                /// assert_eq!(chars.get_inner(), "abc");
+                /// chars.next();
+                /// assert_eq!(chars.get_inner(), "abc");
+                /// chars.next();
+                /// chars.next();
+                /// assert_eq!(chars.get_inner(), "abc");
+                /// ```
+                pub fn get_inner(&self) -> &str {
+                    &self.s
+                }
+
                 #[delegate(self.i)]
                 /// Borrow the contained String
                 pub fn as_str(&self) -> &str;


### PR DESCRIPTION
That pull request adds method to get string slice of source of an iteration without consuming it.

# Motivation

I use `OwnedCharIndices` in parser as input for lexer. However, sometimes an error occurs, and parser needs to retrieve source code (for example, to print error report). Often parser may recover from the error, so consuming iterator is not the best option.

# Naming

I find name `get_inner` most suitable, because it correlates with already existing `into_inner` method. Moreover, `get_` prefix is often used for methods that get reference to inner value of the structure.