### PR TITLE
Remove `delegate-attr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ homepage = "https://github.com/durka/owned-chars"
 repository = "https://github.com/durka/owned-chars"
 license = "MIT/Apache-2.0"
 keywords = ["chars", "string", "owned", "iterator"]
-
-[dependencies]
-delegate-attr = "0.2.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
 //! Do you think this should be included in Rust proper? [Comment
 //! here](https://github.com/durka/owned-chars/issues/5) if so!
 
-#[macro_use]
-extern crate delegate_attr;
-
 /// Extension trait for String providing owned char and char-index iterators
 pub trait OwnedCharsExt {
     /// Gets an owning iterator over the chars (see `chars()`)
@@ -91,24 +88,33 @@ mod structs {
                     &self.s
                 }
 
-                #[delegate(self.i)]
                 /// Borrow the contained String
-                pub fn as_str(&self) -> &str;
+                pub fn as_str(&self) -> &str {
+                    self.i.as_str()
+                }
             }
 
-            #[delegate(self.i)]
             impl Iterator for $owned_struct {
                 type Item = $item;
 
-                fn next(&mut self) -> Option<$item>;
-                fn count(self) -> usize;
-                fn size_hint(&self) -> (usize, Option<usize>);
-                fn last(self) -> Option<$item>;
+                fn next(&mut self) -> Option<$item> {
+                    self.i.next()
+                }
+                fn count(self) -> usize {
+                    self.i.count()
+                }
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    self.i.size_hint()
+                }
+                fn last(self) -> Option<$item> {
+                    self.i.last()
+                }
             }
 
-            #[delegate(self.i)]
             impl DoubleEndedIterator for $owned_struct {
-                fn next_back(&mut self) -> Option<$item>;
+                fn next_back(&mut self) -> Option<$item> {
+                    self.i.next_back()
+                }
             }
 
             impl FusedIterator for $owned_struct {}


### PR DESCRIPTION
As was discussed, there is an proposed removal of `delegate-attr`. Only six additional lines of source code (braces don't count). Cold compilation time of release profile on my machine decreased from ~4.25s to ~0.12s.